### PR TITLE
prevent the inclusion of local/ in the packaged dist; include META.json v2 data

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,6 +5,7 @@ copyright_holder = Chris Prather
 copyright_year   = 2013
 
 [@Basic]
+[MetaJSON]
 [PkgVersion]
 
 [AutoPrereqs]
@@ -14,6 +15,7 @@ filenames = Makefile.PL
 match = ^nytprof.*
 match = ^perl5
 match = ^cpan.*
+match = ^local
 
 [Test::Compile]
 


### PR DESCRIPTION
metacpan is getting confused by the inclusion of modules in local/ - stop shipping them!

https://github.com/CPAN-API/metacpan-web/issues/1239
