### PR TITLE
add HTTP::Throwable exceptions

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'File::Find';
 requires 'File::Temp';
 requires 'HTTP::Request::Common';
 requires 'HTTP::Thin';
+requires 'HTTP::Throwable::Factory';
 requires 'Import::Into';
 requires 'JSON::Any';
 requires 'Moo';

--- a/lib/HTTP/Thin/UserAgent.pm
+++ b/lib/HTTP/Thin/UserAgent.pm
@@ -103,29 +103,23 @@ use warnings;
         my $res = $ua->request($request);
         warn $res->dump if TRACE;
 
-        return $res if $res->is_success;
+        if ($res->is_error) {
 
-        # we got an error ... let's figure it out
-
-        my $e;
-        if ($res->is_server_error) {
-            $e = HTTPException->new_exception({
+            my $e = HTTPException->new_exception({
                 status_code => $res->code,
                 reason => $res->message,
                 additional_headers => {
                     $res->headers->flatten,
-                }
-            });
-        }
-        if ($res->is_client_error) {
-           $e =  UnexpectedResponse->new(
-                message => $res->message,
+                },
                 response => $res,
-           );
-        }
-        for ($e) {
+            });
+
+            for ($e) {
                 $self->on_error->($e);
+            }
         }
+
+        return $res;
     }
 
     sub as_json {

--- a/lib/HTTP/Thin/UserAgent.pm
+++ b/lib/HTTP/Thin/UserAgent.pm
@@ -245,9 +245,7 @@ __END__
 
 =head1 DESCRIPTION
 
-WARNING this code is still *alpha* quality. While it will work as advertised on the tin, API breakage may occure as things settle.
-
-C<HTTP::Thin::UserAgent> provides what I hope is a thin layer over L<HTTP::Thin>. It exposes an functional API that hopefully makes writing HTTP clients easier. Right now it's in *very* alpha stage and really only helps for writing JSON clients. The intent is to expand it to be more generally useful but a JSON client was what I needed first.
+C<HTTP::Thin::UserAgent> provides a layer over L<HTTP::Thin>. It exposes an functional API that hopefully makes writing HTTP clients easier.
 
 =head1 EXPORTS
 
@@ -299,7 +297,8 @@ Takes a CSS or XPath expression and returns an arrayref of L<HTML::Treebuilder::
 
 =item on_error( $coderef )
 
-A code reference that if there is an error in fetching the HTTP response handles that error. C<$_> will be set to the error being handled.
+A code reference that if there is an error in fetching the HTTP response handles that error. C<$_> will be set to the error being handled. Exceptions are
+L<HTTP::Throwable> objects for server side errors.
 
 =back
 

--- a/lib/HTTP/Thin/UserAgent.pm
+++ b/lib/HTTP/Thin/UserAgent.pm
@@ -108,9 +108,9 @@ use warnings;
             my $e = HTTPException->new_exception({
                 status_code => $res->code,
                 reason => $res->message,
-                additional_headers => {
-                    $res->headers->flatten,
-                },
+                additional_headers => [
+                     $res->headers->flatten(),
+                ],
                 response => $res,
             });
 

--- a/t/03.exception.t
+++ b/t/03.exception.t
@@ -1,0 +1,19 @@
+#!usr/bin/env perl
+use strict;
+use Test::More;
+
+use HTTP::Thin::UserAgent;
+use Test::Requires::Env qw(
+  LIVE_HTTP_TESTS
+);
+
+{
+    my $uri  = 'http://perigr.in/will-never-exist-'.time;
+    my $resp = http( GET $uri )->on_error(sub {
+        ok ref $_, 'got an exception object';
+        is $_->status_code, '404', 'got a 404';
+        is ref $_->response, 'HTTP::Response', 'got a response object too';
+    })->response;
+}
+
+done_testing;


### PR DESCRIPTION
So when we get back Server Errors it would be nice to get exceptions
for those errors and trigger calls to `on_error` rather than letting
them slide past silently.

This commit adds HTTP::Throwable to the mix so when we get an error
response that is translated into the appropriate HTTP::Throwable
exception object. I've subclassed HTTP::Throwable::Factory so that
every exception object can hold a reference to the response object
that generated the exception.